### PR TITLE
Ignore drag gestures if no actions are provided

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -208,7 +208,7 @@ class _SwipeActionPageState extends State<SwipeActionPage> {
       ],
       child: GestureDetector(
         onTap: () {
-          Scaffold.of(ctx)
+          ScaffoldMessenger.of(ctx)
             ..showSnackBar(SnackBar(
               content: Text(
                 'tap',

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,56 +5,56 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.3"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
   flutter:
@@ -78,21 +78,21 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
   sky_engine:
@@ -104,56 +104,56 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
 sdks:

--- a/lib/core/cell.dart
+++ b/lib/core/cell.dart
@@ -705,7 +705,8 @@ class SwipeActionCellState extends State<SwipeActionCell>
 
     whenTrailingActionShowing = currentOffset.dx < 0;
     whenLeadingActionShowing = currentOffset.dx > 0;
-    cellStateInfo.isActionShowing = whenTrailingActionShowing || whenLeadingActionShowing;
+    cellStateInfo.isActionShowing =
+        whenTrailingActionShowing || whenLeadingActionShowing;
 
     return IgnorePointer(
       ignoring: ignorePointer,
@@ -751,11 +752,9 @@ class SwipeActionCellState extends State<SwipeActionCell>
                   GestureRecognizerFactoryWithHandlers<
                           DirectionDependentDragGestureRecognizer>(
                       () => DirectionDependentDragGestureRecognizer(
-                        cellStateInfo: cellStateInfo,
-                          canDragToLeft:
-                              currentOffset != Offset.zero || hasTrailingAction,
-                          canDragToRight: currentOffset != Offset.zero ||
-                              hasLeadingAction), (instance) {
+                          cellStateInfo: cellStateInfo,
+                          canDragToLeft: hasTrailingAction,
+                          canDragToRight: hasLeadingAction), (instance) {
                 instance
                   ..onStart = _onHorizontalDragStart
                   ..onUpdate = _onHorizontalDragUpdate

--- a/lib/core/cell.dart
+++ b/lib/core/cell.dart
@@ -176,7 +176,7 @@ class SwipeActionCellState extends State<SwipeActionCell>
 
   int get leadingActionsCount => widget.leadingActions?.length ?? 0;
 
-  final cellStateInfo = CellStateInfo();
+  final cellStateInfo = _CellStateInfo();
 
   @override
   void initState() {
@@ -748,10 +748,10 @@ class SwipeActionCellState extends State<SwipeActionCell>
                     : null;
             }),
             if (widget.isDraggable)
-              DirectionDependentDragGestureRecognizer:
+              _DirectionDependentDragGestureRecognizer:
                   GestureRecognizerFactoryWithHandlers<
-                          DirectionDependentDragGestureRecognizer>(
-                      () => DirectionDependentDragGestureRecognizer(
+                          _DirectionDependentDragGestureRecognizer>(
+                      () => _DirectionDependentDragGestureRecognizer(
                           cellStateInfo: cellStateInfo,
                           canDragToLeft: hasTrailingAction,
                           canDragToRight: hasLeadingAction), (instance) {
@@ -1068,13 +1068,13 @@ class SwipeNestedAction {
   });
 }
 
-class DirectionDependentDragGestureRecognizer
+class _DirectionDependentDragGestureRecognizer
     extends HorizontalDragGestureRecognizer {
   final bool canDragToLeft;
   final bool canDragToRight;
-  final CellStateInfo cellStateInfo;
+  final _CellStateInfo cellStateInfo;
 
-  DirectionDependentDragGestureRecognizer(
+  _DirectionDependentDragGestureRecognizer(
       {required this.cellStateInfo,
       required this.canDragToLeft,
       required this.canDragToRight});
@@ -1091,6 +1091,6 @@ class DirectionDependentDragGestureRecognizer
   }
 }
 
-class CellStateInfo {
+class _CellStateInfo {
   bool isActionShowing = false;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,49 +5,49 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
   flutter:
@@ -64,21 +64,21 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
   sky_engine:
@@ -90,56 +90,56 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
 sdks:


### PR DESCRIPTION
Use case: chat in the tab - with reply by swipe from one edge and switch tab by swipe from other edge. At the moment horizontal drag in both axis intercepted by GestureDetector even if trailing or  leading actions are empty.