### PR TITLE
Add dispose to SwipeActionController

### DIFF
--- a/lib/core/controller.dart
+++ b/lib/core/controller.dart
@@ -187,4 +187,8 @@ class SwipeActionController {
         .bus
         .fire(EditingModeEvent(controller: controller, editing: editing));
   }
+
+  void dispose() {
+    isEditing.dispose();
+  }
 }

--- a/test/tests.dart
+++ b/test/tests.dart
@@ -109,5 +109,7 @@ void main() {
     await tester.timedDrag(
         find.byKey(key), const Offset(100, 0), const Duration(milliseconds: 100));
     expect(find.text('leadingActions 1'), findsNothing);
+
+    controller.dispose();
   });
 }


### PR DESCRIPTION
SwipeActionController内部创建了一个 `ValueNotifier<bool> isEditing` 但是没有提供`dispose`方法, 如果对isEditing进行addListener操作可能会导致内存泄漏.

虽然在外部可以直接调用isEditing.dispose()进行销毁, 但是这么做违背了谁创建谁销毁思想, 所以添加了一个dispose进行主动销毁