### PR TITLE
Add hasAnyOpenCell to query whether any cell is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+## [3.1.8] Add `SwipeActionController.hasAnyOpenCell` / `SwipeActionStore.anyCellOpen` to query whether any cell is open
 ## [3.1.7] Fix leaks and CI
 ## [3.1.6] Fix #78
 ## [3.1.5] Fix #71 (Assertion error during selectCellAt on second list)

--- a/README-CN.md
+++ b/README-CN.md
@@ -26,7 +26,7 @@ Alipay | Wechat |
 #### pub 仓库点这里： [pub](https://pub.dev/packages/flutter_swipe_action_cell)
 #### 安装：
 ```yaml
-flutter_swipe_action_cell: ^3.1.7
+flutter_swipe_action_cell: ^3.1.8
 ```
 
  <br/>

--- a/README-CN.md
+++ b/README-CN.md
@@ -276,6 +276,9 @@ controller.openCellAt(index: 2, trailing: true, animated: true);
 /// 关闭 cell
 controller.closeAllOpenCell();
 
+/// 当前是否有任意 cell 处于打开态（例如让返回手势先关闭它）
+bool hasOpen = controller.hasAnyOpenCell;
+
 /// 切换编辑模式
 controller.toggleEditingMode()
 
@@ -519,6 +522,7 @@ isEditing | 是否处于编辑模式
 selectedIndexPathsChangeCallback|获取选择/取消选择cell的回调
 openCellAt|打开特定位置的cell
 closeAllOpenCell|关闭所有打开的cell
+hasAnyOpenCell|当前是否有任意 cell 处于打开态
 getSelectedIndexPaths() | 获取选中的行的索引集合
 toggleEditingMode() | 切换编辑模式
 stopEditingMode()|暂停编辑模式

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Alipay | Wechat |
 ##### install:
 
 ```yaml
-flutter_swipe_action_cell: ^3.1.7
+flutter_swipe_action_cell: ^3.1.8
 ```  
 
 ## 1.Preview：

--- a/README.md
+++ b/README.md
@@ -262,6 +262,9 @@ controller.openCellAt(index: 2, trailing: true, animated: true);
 /// close cell
 controller.closeAllOpenCell();
 
+/// whether any cell is currently open (e.g. to let a back gesture close it first)
+bool hasOpen = controller.hasAnyOpenCell;
+
 /// toggleEditingMode
 controller.toggleEditingMode()
 

--- a/lib/core/cell.dart
+++ b/lib/core/cell.dart
@@ -164,7 +164,25 @@ class SwipeActionCellState extends State<SwipeActionCell>
     with TickerProviderStateMixin {
   double width = 0;
 
-  late Offset currentOffset;
+  Offset _currentOffset = Offset.zero;
+
+  /// The cell's current horizontal offset. Wrapped with a setter so the global
+  /// open-cell set ([SwipeActionStore.openCells]) stays in sync with the real
+  /// open/closed state (dx != 0 means open), letting callers query
+  /// [SwipeActionStore.anyCellOpen] without needing a close event.
+  Offset get currentOffset => _currentOffset;
+
+  set currentOffset(Offset value) {
+    if (_currentOffset == value) return;
+    _currentOffset = value;
+    final SwipeActionStore store = SwipeActionStore.getInstance();
+    if (value.dx != 0.0) {
+      store.openCells.add(this);
+    } else {
+      store.openCells.remove(this);
+    }
+  }
+
   late double maxTrailingPullWidth;
   late double maxLeadingPullWidth;
 
@@ -393,6 +411,7 @@ class SwipeActionCellState extends State<SwipeActionCell>
 
   @override
   void dispose() {
+    SwipeActionStore.getInstance().openCells.remove(this);
     _removeScrollListener();
     openCurvedAnim.dispose();
     closeCurvedAnim.dispose();

--- a/lib/core/cell.dart
+++ b/lib/core/cell.dart
@@ -167,20 +167,27 @@ class SwipeActionCellState extends State<SwipeActionCell>
   Offset _currentOffset = Offset.zero;
 
   /// The cell's current horizontal offset. Wrapped with a setter so the global
-  /// open-cell set ([SwipeActionStore.openCells]) stays in sync with the real
-  /// open/closed state (dx != 0 means open), letting callers query
-  /// [SwipeActionStore.anyCellOpen] without needing a close event.
+  /// open-cell set stays in sync with the real open/closed state, letting callers
+  /// query [SwipeActionStore.anyCellOpen] without needing a close event.
+  ///
+  /// A cell counts as "open" only when its action buttons are showing, i.e. the
+  /// offset is non-zero AND it is not in (or animating in/out of) edit mode —
+  /// edit mode also drives [currentOffset] (to [SwipeActionCell.editModeOffset])
+  /// but intentionally hides the action buttons.
   Offset get currentOffset => _currentOffset;
 
   set currentOffset(Offset value) {
     if (_currentOffset == value) return;
     _currentOffset = value;
-    final SwipeActionStore store = SwipeActionStore.getInstance();
-    if (value.dx != 0.0) {
-      store.openCells.add(this);
-    } else {
-      store.openCells.remove(this);
-    }
+    SwipeActionStore.getInstance()
+        .setCellOpen(this, value.dx != 0.0 && !_inEditContext);
+  }
+
+  /// True while this cell is in edit mode or animating into/out of it, during
+  /// which a non-zero [currentOffset] is the edit-mode offset, not an open cell.
+  bool get _inEditContext {
+    if (widget.controller?.isEditing.value ?? false) return true;
+    return editController.isAnimating;
   }
 
   late double maxTrailingPullWidth;
@@ -411,7 +418,7 @@ class SwipeActionCellState extends State<SwipeActionCell>
 
   @override
   void dispose() {
-    SwipeActionStore.getInstance().openCells.remove(this);
+    SwipeActionStore.getInstance().setCellOpen(this, false);
     _removeScrollListener();
     openCurvedAnim.dispose();
     closeCurvedAnim.dispose();

--- a/lib/core/controller.dart
+++ b/lib/core/controller.dart
@@ -28,9 +28,6 @@ class SwipeActionController {
   ///
   /// Useful when a page-level back gesture wants to close the open cell first
   /// (via [closeAllOpenCell]) instead of leaving the page.
-  ///
-  /// 当前是否有任意 cell 处于打开态（露出操作按钮）。
-  /// 适合页面级返回手势据此先 [closeAllOpenCell] 关闭，而不是直接返回。
   bool get hasAnyOpenCell => SwipeActionStore.getInstance().anyCellOpen;
 
   /// edit mode or not

--- a/lib/core/controller.dart
+++ b/lib/core/controller.dart
@@ -24,6 +24,15 @@ class SwipeActionController {
 
   SelectedIndexPathsChangeCallback? selectedIndexPathsChangeCallback;
 
+  /// Whether any cell is currently open (its action buttons are showing).
+  ///
+  /// Useful when a page-level back gesture wants to close the open cell first
+  /// (via [closeAllOpenCell]) instead of leaving the page.
+  ///
+  /// 当前是否有任意 cell 处于打开态（露出操作按钮）。
+  /// 适合页面级返回手势据此先 [closeAllOpenCell] 关闭，而不是直接返回。
+  bool get hasAnyOpenCell => SwipeActionStore.getInstance().anyCellOpen;
+
   /// edit mode or not
   ///
   /// 获取是否正处于编辑模式

--- a/lib/core/store.dart
+++ b/lib/core/store.dart
@@ -4,6 +4,15 @@ class SwipeActionStore {
   static SwipeActionStore? _instance;
   late SwipeActionBus bus;
 
+  /// Cells that are currently open (offset != 0), tracked by their State object.
+  /// Maintained by [SwipeActionCellState.currentOffset]'s setter and cleared on
+  /// dispose, so it always reflects the real open/closed state (no event needed).
+  final Set<Object> openCells = <Object>{};
+
+  /// Whether any cell is currently open. Lets callers (e.g. a page-level
+  /// swipe-to-pop gesture) close the open cell first instead of popping.
+  bool get anyCellOpen => openCells.isNotEmpty;
+
   static SwipeActionStore getInstance() {
     if (_instance == null) {
       _instance = SwipeActionStore();

--- a/lib/core/store.dart
+++ b/lib/core/store.dart
@@ -4,14 +4,27 @@ class SwipeActionStore {
   static SwipeActionStore? _instance;
   late SwipeActionBus bus;
 
-  /// Cells that are currently open (offset != 0), tracked by their State object.
-  /// Maintained by [SwipeActionCellState.currentOffset]'s setter and cleared on
-  /// dispose, so it always reflects the real open/closed state (no event needed).
-  final Set<Object> openCells = <Object>{};
+  /// Cells that are currently open (action buttons showing), tracked by their
+  /// State object. Maintained via [setCellOpen] from
+  /// [SwipeActionCellState.currentOffset]'s setter and cleared on dispose, so it
+  /// always reflects the real open/closed state (no close event needed).
+  ///
+  /// Kept private so external callers can't corrupt it (e.g. clear it); use
+  /// [anyCellOpen] to read and [setCellOpen] to update.
+  final Set<Object> _openCells = <Object>{};
 
   /// Whether any cell is currently open. Lets callers (e.g. a page-level
   /// swipe-to-pop gesture) close the open cell first instead of popping.
-  bool get anyCellOpen => openCells.isNotEmpty;
+  bool get anyCellOpen => _openCells.isNotEmpty;
+
+  /// Marks [cell] as open or closed in the global open-cell set.
+  void setCellOpen(Object cell, bool open) {
+    if (open) {
+      _openCells.add(cell);
+    } else {
+      _openCells.remove(cell);
+    }
+  }
 
   static SwipeActionStore getInstance() {
     if (_instance == null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_swipe_action_cell
 description: An awesome UI package incluing iOS style cell swipe action effect.You can use this package to implement iOS style tableView cell swipe action
-version: 3.1.7
+version: 3.1.8
 homepage: https://github.com/luckysmg/flutter_swipe_action_cell
 
 environment:

--- a/test/has_any_open_cell_test.dart
+++ b/test/has_any_open_cell_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_swipe_action_cell/flutter_swipe_action_cell.dart';
+
+void main() {
+  /// Pumps a list of [count] swipe cells (each with one trailing action) wired
+  /// to [controller], and returns the keys of the cells in order.
+  Future<List<GlobalKey>> pumpCells(
+    WidgetTester tester,
+    SwipeActionController controller, {
+    int count = 1,
+  }) async {
+    final List<GlobalKey> keys =
+        List<GlobalKey>.generate(count, (_) => GlobalKey());
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ListView(
+            children: [
+              for (int i = 0; i < count; i++)
+                SwipeActionCell(
+                  key: keys[i],
+                  controller: controller,
+                  index: i,
+                  trailingActions: [
+                    SwipeAction(onTap: (handler) {}, title: 'action $i'),
+                  ],
+                  child: Container(color: Colors.red, height: 100),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return keys;
+  }
+
+  Future<void> openCell(WidgetTester tester, Key key) async {
+    await tester.timedDrag(
+      find.byKey(key),
+      const Offset(-100, 0),
+      const Duration(milliseconds: 100),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('hasAnyOpenCell is false before any cell is opened.',
+      (tester) async {
+    final SwipeActionController controller = SwipeActionController();
+    await pumpCells(tester, controller);
+
+    expect(controller.hasAnyOpenCell, isFalse);
+
+    controller.dispose();
+  });
+
+  testWidgets('hasAnyOpenCell becomes true after a cell is swiped open.',
+      (tester) async {
+    final SwipeActionController controller = SwipeActionController();
+    final keys = await pumpCells(tester, controller);
+
+    await openCell(tester, keys.first);
+    // The trailing action is revealed, so the cell is open.
+    expect(find.text('action 0'), findsOneWidget);
+    expect(controller.hasAnyOpenCell, isTrue);
+
+    controller.closeAllOpenCell();
+    await tester.pumpAndSettle();
+    controller.dispose();
+  });
+
+  testWidgets('hasAnyOpenCell becomes false again after closeAllOpenCell.',
+      (tester) async {
+    final SwipeActionController controller = SwipeActionController();
+    final keys = await pumpCells(tester, controller);
+
+    await openCell(tester, keys.first);
+    expect(controller.hasAnyOpenCell, isTrue);
+
+    controller.closeAllOpenCell();
+    await tester.pumpAndSettle();
+    expect(controller.hasAnyOpenCell, isFalse);
+
+    controller.dispose();
+  });
+
+  testWidgets(
+      'hasAnyOpenCell stays true while one of several open cells is closed.',
+      (tester) async {
+    final SwipeActionController controller = SwipeActionController();
+    final keys = await pumpCells(tester, controller, count: 2);
+
+    await openCell(tester, keys[0]);
+    expect(controller.hasAnyOpenCell, isTrue);
+
+    // Opening a second cell closes the first automatically (single-open
+    // behaviour), but there is still an open cell.
+    await openCell(tester, keys[1]);
+    expect(controller.hasAnyOpenCell, isTrue);
+
+    controller.closeAllOpenCell();
+    await tester.pumpAndSettle();
+    expect(controller.hasAnyOpenCell, isFalse);
+
+    controller.dispose();
+  });
+
+  testWidgets('hasAnyOpenCell becomes false when the open cell is disposed.',
+      (tester) async {
+    final SwipeActionController controller = SwipeActionController();
+    final keys = await pumpCells(tester, controller);
+
+    await openCell(tester, keys.first);
+    expect(controller.hasAnyOpenCell, isTrue);
+
+    // Remove the cell from the tree without closing it first; dispose must
+    // still clear it from the open-cell set.
+    await tester.pumpWidget(const MaterialApp(home: Scaffold()));
+    await tester.pumpAndSettle();
+    expect(controller.hasAnyOpenCell, isFalse);
+
+    controller.dispose();
+  });
+}

--- a/test/has_any_open_cell_test.dart
+++ b/test/has_any_open_cell_test.dart
@@ -122,4 +122,22 @@ void main() {
 
     controller.dispose();
   });
+
+  testWidgets('hasAnyOpenCell stays false in edit mode (no action buttons).',
+      (tester) async {
+    final SwipeActionController controller = SwipeActionController();
+    await pumpCells(tester, controller);
+
+    // Edit mode drives currentOffset to editModeOffset, but the action buttons
+    // are intentionally hidden, so the cell must not count as "open".
+    controller.startEditingMode();
+    await tester.pumpAndSettle();
+    expect(controller.hasAnyOpenCell, isFalse);
+
+    controller.stopEditingMode();
+    await tester.pumpAndSettle();
+    expect(controller.hasAnyOpenCell, isFalse);
+
+    controller.dispose();
+  });
 }


### PR DESCRIPTION
## What

- Add `SwipeActionController.hasAnyOpenCell` (backed by `SwipeActionStore.anyCellOpen`) to query whether any cell is currently open.
- Track open cells in `SwipeActionStore.openCells` via the `SwipeActionCellState.currentOffset` setter, removed on `dispose` — so the state always reflects the real open/closed cells without needing a close event.

## Why

A page-level back gesture (e.g. swipe-to-pop) often wants to first close an open cell instead of leaving the page. Today there is no way to know whether any cell is open, because the package only fires an event on open, never on close.

## Notes

- Backward compatible; no public API removed or changed.
- `currentOffset` becomes a getter/setter over a private field; all existing assignments keep working.
- Updated CHANGELOG and bumped version to 3.1.8.