### PR TITLE
fix: don't clip elevation shadows in SwipeActionCell (#81)

### DIFF
--- a/lib/core/cell.dart
+++ b/lib/core/cell.dart
@@ -918,6 +918,11 @@ class SwipeActionCellState extends State<SwipeActionCell>
                       : _buildLeadingActionButtons();
                   return Stack(
                     alignment: Alignment.centerLeft,
+                    // Do not clip the child's overflow (e.g. an elevation
+                    // shadow) at the cell's boundaries. The action buttons are
+                    // pushed off-screen and clipped by their own inner Stacks,
+                    // so disabling clipping here is safe. See issue #81.
+                    clipBehavior: Clip.none,
                     children: <Widget>[
                       selectedButton,
                       content,

--- a/test/shadow_clipping_test.dart
+++ b/test/shadow_clipping_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_swipe_action_cell/flutter_swipe_action_cell.dart';
+
+void main() {
+  // Regression test for issue #81: the child's overflow (e.g. an elevation
+  // shadow) must not be clipped at the cell's top/bottom boundaries. The cell
+  // lays out its content and action buttons inside a Stack; that Stack must not
+  // clip so the child can paint beyond the cell bounds.
+  testWidgets(
+      'SwipeActionCell does not clip its content (allows shadow overflow).',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ListView(
+            children: [
+              SwipeActionCell(
+                key: const ValueKey('cell'),
+                trailingActions: [
+                  SwipeAction(onTap: (handler) {}, title: 'delete'),
+                ],
+                child: Container(color: Colors.red, height: 100),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // The only Stack inside the closed cell is the layout Stack that wraps the
+    // content and (hidden) action buttons.
+    final Iterable<Stack> stacks = tester.widgetList<Stack>(
+      find.descendant(
+        of: find.byType(SwipeActionCell),
+        matching: find.byType(Stack),
+      ),
+    );
+
+    expect(stacks, isNotEmpty);
+    for (final Stack stack in stacks) {
+      expect(
+        stack.clipBehavior,
+        Clip.none,
+        reason: 'The cell layout Stack must not clip the child overflow.',
+      );
+    }
+  });
+}


### PR DESCRIPTION
Fixes #81

## Symptom

When a `SwipeActionCell` wraps a child that paints outside its bounds — typically a `Card`/`Material` with elevation — the shadow is cut off at the cell's top and bottom edges. The outer layout `Stack` in `lib/core/cell.dart` uses the default `clipBehavior` (`Clip.hardEdge`), so anything the child paints beyond the cell rectangle is clipped.

## Fix

Set `clipBehavior: Clip.none` on that outer `Stack` so the child's shadow can paint past the cell bounds.

This is safe with respect to the swipe actions: the trailing/leading action buttons are positioned off-screen and are clipped by their own inner `Stack`s (`_buildTrailingActionButtons` / `_buildLeadingActionButtons`), so they stay hidden while the cell is closed or mid-swipe. Only the content's own overflow (the shadow) becomes visible. A code comment at the call site documents this.

## Testing

- Added `test/shadow_clipping_test.dart`, which builds a `SwipeActionCell` with an elevated child and asserts the cell no longer clips its content's overflow.
- Ran `flutter test test/shadow_clipping_test.dart` locally (Flutter 3.44.1 / Dart 3.12.1): all tests passing.
